### PR TITLE
use latest pangeo docker image

### DIFF
--- a/binder-gallery.yaml
+++ b/binder-gallery.yaml
@@ -4,6 +4,6 @@ description: >-
   A notebook accessing CCMP wind data in Zarr format.
 gallery_repository: pangeo-gallery/pangeo-gallery
 binder_url: "https://binder.pangeo.io"
-binder_repo: pangeo-gallery/default-binder
-binder_ref: master
+binder_repo: pangeo-data/pangeo-docker-images
+binder_ref: 2021.10.19
 binderbot_target_branch: binderbot-built


### PR DESCRIPTION
Now that we can point directly to pangeo-docker-images, I'm updating these tags.